### PR TITLE
Convert Next.js app to static site for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # Or your default branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Allow write access to repository contents
+      pages: write    # Allow write access to GitHub Pages
+      id-token: write # Allow OIDC token generation for GitHub Pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20' # Specify your Node.js version
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Next.js application
+        run: npm run build
+        env:
+          # If you have any build-time environment variables, define them here
+          # NEXT_PUBLIC_VARIABLE_NAME: ${{ secrets.VARIABLE_NAME }}
+          # For example, if basePath was dynamic (it's not in our case currently)
+          # NEXT_PUBLIC_BASE_PATH: /depotu
+          # However, since basePath is in next.config.js, this is not strictly needed here for that specific var.
+          CI: true
+
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './out' # Deploy the 'out' folder
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,13 +2,16 @@ import type {NextConfig} from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */
+  output: 'export',
+  basePath: '/depotu',
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   images: {
+    unoptimized: true, // Added for static export compatibility
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
- Configured Next.js for static export (`output: 'export'`).
- Set `basePath` to '/depotu' for GitHub Pages deployment.
- Added `images: { unoptimized: true }` for static image handling.
- Updated build script in `package.json`.
- Added GitHub Actions workflow for automated deployment to GitHub Pages.
- Confirmed that existing AI/Firebase backend features are not used in the main page and thus excluded from static export.